### PR TITLE
WHIP: Fix bugs

### DIFF
--- a/libavformat/tls_openssl.c
+++ b/libavformat/tls_openssl.c
@@ -415,7 +415,7 @@ error:
  */
 static EVP_PKEY *pkey_from_pem_string(const char *pem_str, int is_priv)
 {
-    BIO *mem = BIO_new_mem_buf(pem_str, -1);
+    BIO *mem = BIO_new_mem_buf((void *)pem_str, -1);
     if (!mem) {
         av_log(NULL, AV_LOG_ERROR, "BIO_new_mem_buf failed\n");
         return NULL;
@@ -445,7 +445,7 @@ static EVP_PKEY *pkey_from_pem_string(const char *pem_str, int is_priv)
  */
 static X509 *cert_from_pem_string(const char *pem_str)
 {
-    BIO *mem = BIO_new_mem_buf(pem_str, -1);
+    BIO *mem = BIO_new_mem_buf((void *)pem_str, -1);
     if (!mem) {
         av_log(NULL, AV_LOG_ERROR, "BIO_new_mem_buf failed\n");
         return NULL;

--- a/libavformat/tls_openssl.c
+++ b/libavformat/tls_openssl.c
@@ -415,11 +415,10 @@ error:
  */
 static EVP_PKEY *pkey_from_pem_string(const char *pem_str, int is_priv)
 {
-    BIO *mem = NULL;
 #if OPENSSL_VERSION_NUMBER < 0x10002000L /* OpenSSL 1.0.2 */
-    mem = BIO_new_mem_buf((void *)pem_str, -1);
+    BIO *mem = BIO_new_mem_buf((void *)pem_str, -1);
 #else
-    mem = BIO_new_mem_buf(pem_str, -1);
+    BIO *mem = BIO_new_mem_buf(pem_str, -1);
 #endif
     if (!mem) {
         av_log(NULL, AV_LOG_ERROR, "BIO_new_mem_buf failed\n");
@@ -450,11 +449,10 @@ static EVP_PKEY *pkey_from_pem_string(const char *pem_str, int is_priv)
  */
 static X509 *cert_from_pem_string(const char *pem_str)
 {
-    BIO *mem = NULL;
 #if OPENSSL_VERSION_NUMBER < 0x10002000L /* OpenSSL 1.0.2 */
-    mem = BIO_new_mem_buf((void *)pem_str, -1);
+    BIO *mem = BIO_new_mem_buf((void *)pem_str, -1);
 #else
-    mem = BIO_new_mem_buf(pem_str, -1);
+    BIO *mem = BIO_new_mem_buf(pem_str, -1);
 #endif
     if (!mem) {
         av_log(NULL, AV_LOG_ERROR, "BIO_new_mem_buf failed\n");

--- a/libavformat/tls_openssl.c
+++ b/libavformat/tls_openssl.c
@@ -415,7 +415,12 @@ error:
  */
 static EVP_PKEY *pkey_from_pem_string(const char *pem_str, int is_priv)
 {
-    BIO *mem = BIO_new_mem_buf((void *)pem_str, -1);
+    BIO *mem = NULL;
+#if OPENSSL_VERSION_NUMBER < 0x10002000L /* OpenSSL 1.0.2 */
+    mem = BIO_new_mem_buf((void *)pem_str, -1);
+#else
+    mem = BIO_new_mem_buf(pem_str, -1);
+#endif
     if (!mem) {
         av_log(NULL, AV_LOG_ERROR, "BIO_new_mem_buf failed\n");
         return NULL;
@@ -445,7 +450,12 @@ static EVP_PKEY *pkey_from_pem_string(const char *pem_str, int is_priv)
  */
 static X509 *cert_from_pem_string(const char *pem_str)
 {
-    BIO *mem = BIO_new_mem_buf((void *)pem_str, -1);
+    BIO *mem = NULL;
+#if OPENSSL_VERSION_NUMBER < 0x10002000L /* OpenSSL 1.0.2 */
+    mem = BIO_new_mem_buf((void *)pem_str, -1);
+#else
+    mem = BIO_new_mem_buf(pem_str, -1);
+#endif
     if (!mem) {
         av_log(NULL, AV_LOG_ERROR, "BIO_new_mem_buf failed\n");
         return NULL;


### PR DESCRIPTION
This PR is based on the whip code in FFmpeg master and #18 , it aims to improve this feature

## Key Changes:
avformat/tls_openssl: fix build error when openssl version < 3

## Progress

the early two commits has been merged in ffmpeg master https://github.com/FFmpeg/FFmpeg/commit/4611ed5cc38d0367186f936dc015a9b3946c3edf

the latest commit `[avformat/tls_openssl: fix warnings when openssl is lower version](https://github.com/ossrs/ffmpeg-webrtc/pull/19/commits/9368f77e9c0071888b92066e98d82d28cf25ebf3)` has been reviewed by Steven Liu, waiting to merge, then this PR will be closed

already has been merged in https://github.com/FFmpeg/FFmpeg/commit/177b92df2b054895f75e3cdd00d68b91a47a243f

## Usage
You can follow the [usage](https://github.com/ossrs/ffmpeg-webrtc/pull/1#usage) to test this patch.