### PR TITLE
avformat/tls_gnutls: fix DTLS handshake failure in some WebRTC cases

### DIFF
--- a/libavformat/tls_gnutls.c
+++ b/libavformat/tls_gnutls.c
@@ -197,7 +197,7 @@ static int gnutls_gen_private_key(gnutls_x509_privkey_t *key)
     }
 
     ret = gnutls_x509_privkey_generate(*key, GNUTLS_PK_ECDSA,
-                                       gnutls_sec_param_to_pk_bits(GNUTLS_PK_ECDSA, GNUTLS_SEC_PARAM_MEDIUM), 0);
+                                       GNUTLS_CURVE_TO_BITS(GNUTLS_ECC_CURVE_SECP256R1), 0);
     if (ret < 0) {
         av_log(NULL, AV_LOG_ERROR, "TLS: Failed to generate private key: %s\n", gnutls_strerror(ret));
         goto einval_end;


### PR DESCRIPTION
The early code may encounter handshake failure when publish WHIP to some server.

See RFC 8827 section 6.5:
All implementations MUST support DTLS 1.2 with the TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 cipher suite and the P-256 curve.

So this patch uses the specific curve to avoid incompatibility.