### PR TITLE
workflows/test: add Windows and macOS build tests for all TLS backends

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -686,7 +686,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tls: [openssl, gnutls, mbedtls]
+        tls: [openssl, gnutls]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -710,20 +710,6 @@ jobs:
           elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
             pacman -S --noconfirm mingw-w64-x86_64-gnutls
           fi
-      - name: Build mbedTLS
-        if: matrix.tls == 'mbedtls'
-        shell: msys2 {0}
-        run: |
-          set -euxo pipefail
-          curl -s -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2 | tar xj
-          cd mbedtls-3.6.2
-          scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
-          mkdir build && cd build
-          CFLAGS="-Wno-error=unterminated-string-initialization" \
-          cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
-            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On \
-            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off ..
-          make -j$(nproc) && make install
       - name: Build FFmpeg
         shell: msys2 {0}
         run: |
@@ -732,15 +718,69 @@ jobs:
             ./configure --enable-muxer=whip --enable-openssl --enable-version3
           elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
             ./configure --enable-muxer=whip --enable-gnutls
-          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
-            PKG_CONFIG_PATH="$HOME/.release/mbedtls/lib/pkgconfig" \
-              ./configure --enable-muxer=whip --enable-mbedtls --enable-version3 \
-              --extra-cflags="-I$HOME/.release/mbedtls/include" \
-              --extra-ldflags="-L$HOME/.release/mbedtls/lib" \
-              --pkg-config-flags="--static"
           fi
           make -j$(nproc)
           ./ffmpeg.exe -version && ./ffmpeg.exe -muxers 2>/dev/null |grep whip
+      - name: Upload FFmpeg binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg-windows-${{ matrix.tls }}
+          path: ./ffmpeg.exe
+          retention-days: 1
+    runs-on: windows-latest
+
+  test-windows:
+    name: "Test FFmpeg on Windows (${{ matrix.tls }})"
+    needs: build-windows
+    strategy:
+      fail-fast: false
+      matrix:
+        tls: [openssl, gnutls]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download FFmpeg binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ffmpeg-windows-${{ matrix.tls }}
+      - name: Verify FFmpeg
+        shell: pwsh
+        run: |
+          .\ffmpeg.exe -version
+          .\ffmpeg.exe -muxers 2>$null | Select-String "whip"
+      - name: Start SRS Docker container
+        shell: pwsh
+        run: |
+          docker run --rm -d -p 1935:1935 -p 1985:1985 -p 8080:8080 -p 8000:8000/udp ossrs/srs:5 ./objs/srs -c conf/rtc2rtmp.conf
+      - name: Streaming with FFmpeg
+        shell: pwsh
+        run: |
+          Start-Process -NoNewWindow -FilePath ".\ffmpeg.exe" -ArgumentList "-t","30","-re","-f","lavfi","-i","testsrc=size=1280x720","-f","lavfi","-i","sine=frequency=440","-pix_fmt","yuv420p","-vcodec","libx264","-profile:v","baseline","-r","25","-g","50","-f","whip","http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream" -RedirectStandardOutput ffstdout.log -RedirectStandardError ffstderr.log
+          Start-Sleep -Seconds 15
+      - name: Check SRS Streaming
+        shell: pwsh
+        run: |
+          for ($i=0; $i -lt 10; $i++) {
+            $response = Invoke-RestMethod -Uri "http://localhost:1985/api/v1/streams/"
+            if ($response.streams.name -contains "livestream") {
+              Write-Host "Test OK"
+              exit 0
+            }
+            Start-Sleep -Seconds 3
+          }
+          Write-Host "Stream not found"
+          exit 1
+      - name: Stop FFmpeg
+        shell: pwsh
+        run: |
+          Get-Process ffmpeg -ErrorAction SilentlyContinue | Stop-Process
+          Start-Sleep -Seconds 3
+      - name: Show FFmpeg Logs
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path ffstdout.log) { Get-Content ffstdout.log }
+          if (Test-Path ffstderr.log) { Get-Content ffstderr.log }
     runs-on: windows-latest
 
   build-macos:
@@ -748,7 +788,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tls: [openssl, gnutls, mbedtls]
+        tls: [openssl, gnutls]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -760,20 +800,7 @@ jobs:
             brew install openssl@3
           elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
             brew install gnutls
-          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
-            brew install cmake
           fi
-      - name: Build mbedTLS
-        if: matrix.tls == 'mbedtls'
-        run: |
-          set -euxo pipefail
-          curl -s -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2 | tar xj
-          cd mbedtls-3.6.2
-          scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
-          mkdir build && cd build
-          cmake -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
-            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On ..
-          make -j$(sysctl -n hw.ncpu) && make install
       - name: Build FFmpeg
         run: |
           set -euxo pipefail
@@ -782,15 +809,69 @@ jobs:
               ./configure --enable-muxer=whip --enable-openssl --enable-version3
           elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
             ./configure --enable-muxer=whip --enable-gnutls
-          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
-            PKG_CONFIG_PATH="$HOME/.release/mbedtls/lib/pkgconfig" \
-              ./configure --enable-muxer=whip --enable-mbedtls --enable-version3 \
-              --extra-cflags="-I$HOME/.release/mbedtls/include" \
-              --extra-ldflags="-L$HOME/.release/mbedtls/lib" \
-              --pkg-config-flags="--static"
           fi
           make -j$(sysctl -n hw.ncpu)
           ./ffmpeg -version && ./ffmpeg -muxers 2>/dev/null |grep whip
+      - name: Upload FFmpeg binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg-macos-${{ matrix.tls }}
+          path: ./ffmpeg
+          retention-days: 1
+    runs-on: macos-latest
+
+  test-macos:
+    name: "Test FFmpeg on macOS (${{ matrix.tls }})"
+    needs: build-macos
+    strategy:
+      fail-fast: false
+      matrix:
+        tls: [openssl, gnutls]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download FFmpeg binary
+        uses: actions/download-artifact@v4
+        with:
+          name: ffmpeg-macos-${{ matrix.tls }}
+      - name: Verify FFmpeg
+        run: |
+          chmod +x ./ffmpeg
+          ./ffmpeg -version && ./ffmpeg -muxers 2>/dev/null |grep whip
+      - name: Start SRS Docker container
+        run: |
+          set -euxo pipefail
+          docker run --rm -d -p 1935:1935 -p 1985:1985 -p 8080:8080 -p 8000:8000/udp \
+            ossrs/srs:5 ./objs/srs -c conf/rtc2rtmp.conf
+      - name: Streaming with FFmpeg
+        run: |
+          set -euxo pipefail
+          nohup ./ffmpeg -t 30 -re -f lavfi -i testsrc=size=1280x720 -f lavfi -i sine=frequency=440 -pix_fmt yuv420p \
+            -vcodec libx264 -profile:v baseline -r 25 -g 50 \
+            -f whip "http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream" \
+            1>ffstdout.log 2>ffstderr.log &
+          sleep 15
+      - name: Check SRS Streaming
+        run: |
+          set -euxo pipefail
+          for ((i=0; i<10; i++)); do
+            STREAM=$(curl -s http://localhost:1985/api/v1/streams/ | jq -r '.streams[].name')
+            if [[ "$STREAM" == "livestream" ]]; then
+              echo 'Test OK'
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "Stream not found"
+          exit 1
+      - name: Stop FFmpeg
+        run: |
+          pkill -SIGINT ffmpeg && sleep 3 || echo "FFmpeg process not found"
+      - name: Show FFmpeg Logs
+        if: always()
+        run: |
+          cat ffstdout.log || true
+          cat ffstderr.log || true
     runs-on: macos-latest
 
   test-done:
@@ -805,7 +886,9 @@ jobs:
       - openssl-3-0
       - openssl-latest
       - build-windows
+      - test-windows
       - build-macos
+      - test-macos
     steps:
       - run: echo 'All done'
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -721,7 +721,8 @@ jobs:
           mkdir build && cd build
           cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
             -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On \
-            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off ..
+            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off \
+            -DCMAKE_C_FLAGS="-Wno-error" ..
           make -j$(nproc) && make install
       - name: Build FFmpeg
         shell: msys2 {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -805,7 +805,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tls: [openssl, gnutls]
+        tls: [openssl, gnutls, mbedtls]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -817,7 +817,21 @@ jobs:
             brew install openssl@3
           elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
             brew install gnutls
+          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
+            brew install cmake
           fi
+      - name: Build mbedTLS
+        if: matrix.tls == 'mbedtls'
+        run: |
+          set -euxo pipefail
+          curl -s -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2 | tar xj
+          cd mbedtls-3.6.2
+          scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
+          mkdir build && cd build
+          cmake -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
+            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On \
+            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off ..
+          make -j$(sysctl -n hw.ncpu) && make install
       - name: Build FFmpeg
         run: |
           set -euxo pipefail
@@ -826,6 +840,12 @@ jobs:
               ./configure --enable-muxer=whip --enable-openssl --enable-version3
           elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
             ./configure --enable-muxer=whip --enable-gnutls
+          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
+            PKG_CONFIG_PATH="$HOME/.release/mbedtls/lib/pkgconfig" \
+              ./configure --enable-muxer=whip --enable-mbedtls --enable-version3 \
+              --extra-cflags="-I$HOME/.release/mbedtls/include" \
+              --extra-ldflags="-L$HOME/.release/mbedtls/lib" \
+              --pkg-config-flags="--static"
           fi
           make -j$(sysctl -n hw.ncpu)
           ./ffmpeg -version && ./ffmpeg -muxers 2>/dev/null |grep whip
@@ -843,7 +863,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tls: [openssl, gnutls]
+        tls: [openssl, gnutls, mbedtls]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -743,6 +743,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ffmpeg-windows-${{ matrix.tls }}
+      - name: Download Test File
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/ossrs/ffmpeg-webrtc/releases/download/pre-release/bbb-4mbps-baseline-opus.mp4" -OutFile "bbb-4mbps-baseline-opus.mp4"
       - name: Verify FFmpeg
         shell: pwsh
         run: |
@@ -774,7 +778,7 @@ jobs:
           }
 
           cd $env:GITHUB_WORKSPACE
-          Start-Process -NoNewWindow -FilePath ".\ffmpeg.exe" -ArgumentList "-t","30","-re","-f","lavfi","-i","testsrc=size=1280x720","-f","lavfi","-i","sine=frequency=440","-pix_fmt","yuv420p","-vcodec","libx264","-profile:v","baseline","-r","25","-g","50","-f","whip","-authorization","seanTest","http://localhost:8080/whip" -RedirectStandardOutput ffstdout.log -RedirectStandardError ffstderr.log
+          Start-Process -NoNewWindow -FilePath ".\ffmpeg.exe" -ArgumentList "-t","30","-re","-i","bbb-4mbps-baseline-opus.mp4","-c","copy","-f","whip","-authorization","seanTest","http://localhost:8080/whip" -RedirectStandardOutput ffstdout.log -RedirectStandardError ffstderr.log
           Start-Sleep -Seconds 10
           Get-Process ffmpeg -ErrorAction SilentlyContinue | Stop-Process
           Start-Sleep -Seconds 3
@@ -847,6 +851,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ffmpeg-macos-${{ matrix.tls }}
+      - name: Download Test File
+        run: |
+          set -euxo pipefail
+          curl -s -L -O https://github.com/ossrs/ffmpeg-webrtc/releases/download/pre-release/bbb-4mbps-baseline-opus.mp4
       - name: Verify FFmpeg
         run: |
           chmod +x ./ffmpeg
@@ -873,8 +881,7 @@ jobs:
           done
 
           cd $GITHUB_WORKSPACE
-          nohup ./ffmpeg -t 30 -re -f lavfi -i testsrc=size=1280x720 -f lavfi -i sine=frequency=440 -pix_fmt yuv420p \
-            -vcodec libx264 -profile:v baseline -r 25 -g 50 \
+          nohup ./ffmpeg -t 30 -re -i bbb-4mbps-baseline-opus.mp4 -c copy \
             -f whip -authorization "seanTest" "http://localhost:8080/whip" \
             1>ffstdout.log 2>ffstderr.log &
           sleep 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -722,7 +722,7 @@ jobs:
           cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
             -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On \
             -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off \
-            -DCMAKE_C_FLAGS="-Wno-error" ..
+            -DCMAKE_C_FLAGS="-Wno-error=stringop-truncation -Wno-stringop-truncation" ..
           make -j$(nproc) && make install
       - name: Build FFmpeg
         shell: msys2 {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -719,10 +719,10 @@ jobs:
           cd mbedtls-3.6.2
           scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
           mkdir build && cd build
+          CFLAGS="-Wno-error=unterminated-string-initialization" \
           cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
             -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On \
-            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off \
-            -DCMAKE_C_FLAGS="-Wno-error=stringop-truncation -Wno-stringop-truncation" ..
+            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off ..
           make -j$(nproc) && make install
       - name: Build FFmpeg
         shell: msys2 {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -720,7 +720,8 @@ jobs:
           scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
           mkdir build && cd build
           cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
-            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On ..
+            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On \
+            -DENABLE_TESTING=Off -DENABLE_PROGRAMS=Off ..
           make -j$(nproc) && make install
       - name: Build FFmpeg
         shell: msys2 {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -681,6 +681,116 @@ jobs:
         run: exit 1
     runs-on: ubuntu-22.04
 
+  build-windows:
+    name: "Build FFmpeg on Windows (${{ matrix.tls }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        tls: [openssl, gnutls, mbedtls]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-nasm
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-cmake
+      - name: Install TLS dependencies
+        shell: msys2 {0}
+        run: |
+          set -euxo pipefail
+          if [[ "${{ matrix.tls }}" == "openssl" ]]; then
+            pacman -S --noconfirm mingw-w64-x86_64-openssl
+          elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
+            pacman -S --noconfirm mingw-w64-x86_64-gnutls
+          fi
+      - name: Build mbedTLS
+        if: matrix.tls == 'mbedtls'
+        shell: msys2 {0}
+        run: |
+          set -euxo pipefail
+          curl -s -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2 | tar xj
+          cd mbedtls-3.6.2
+          scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
+          mkdir build && cd build
+          cmake -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
+            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On ..
+          make -j$(nproc) && make install
+      - name: Build FFmpeg
+        shell: msys2 {0}
+        run: |
+          set -euxo pipefail
+          if [[ "${{ matrix.tls }}" == "openssl" ]]; then
+            ./configure --enable-muxer=whip --enable-openssl --enable-version3
+          elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
+            ./configure --enable-muxer=whip --enable-gnutls
+          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
+            PKG_CONFIG_PATH="$HOME/.release/mbedtls/lib/pkgconfig" \
+              ./configure --enable-muxer=whip --enable-mbedtls --enable-version3 \
+              --extra-cflags="-I$HOME/.release/mbedtls/include" \
+              --extra-ldflags="-L$HOME/.release/mbedtls/lib" \
+              --pkg-config-flags="--static"
+          fi
+          make -j$(nproc)
+          ./ffmpeg.exe -version && ./ffmpeg.exe -muxers 2>/dev/null |grep whip
+    runs-on: windows-latest
+
+  build-macos:
+    name: "Build FFmpeg on macOS (${{ matrix.tls }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        tls: [openssl, gnutls, mbedtls]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          set -euxo pipefail
+          brew install nasm pkg-config
+          if [[ "${{ matrix.tls }}" == "openssl" ]]; then
+            brew install openssl@3
+          elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
+            brew install gnutls
+          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
+            brew install cmake
+          fi
+      - name: Build mbedTLS
+        if: matrix.tls == 'mbedtls'
+        run: |
+          set -euxo pipefail
+          curl -s -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.2/mbedtls-3.6.2.tar.bz2 | tar xj
+          cd mbedtls-3.6.2
+          scripts/config.py set MBEDTLS_SSL_DTLS_SRTP
+          mkdir build && cd build
+          cmake -DCMAKE_INSTALL_PREFIX=$HOME/.release/mbedtls \
+            -DUSE_SHARED_MBEDTLS_LIBRARY=Off -DENABLE_SHARED=Off -DENABLE_STATIC=On ..
+          make -j$(sysctl -n hw.ncpu) && make install
+      - name: Build FFmpeg
+        run: |
+          set -euxo pipefail
+          if [[ "${{ matrix.tls }}" == "openssl" ]]; then
+            PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig" \
+              ./configure --enable-muxer=whip --enable-openssl --enable-version3
+          elif [[ "${{ matrix.tls }}" == "gnutls" ]]; then
+            ./configure --enable-muxer=whip --enable-gnutls
+          elif [[ "${{ matrix.tls }}" == "mbedtls" ]]; then
+            PKG_CONFIG_PATH="$HOME/.release/mbedtls/lib/pkgconfig" \
+              ./configure --enable-muxer=whip --enable-mbedtls --enable-version3 \
+              --extra-cflags="-I$HOME/.release/mbedtls/include" \
+              --extra-ldflags="-L$HOME/.release/mbedtls/lib" \
+              --pkg-config-flags="--static"
+          fi
+          make -j$(sysctl -n hw.ncpu)
+          ./ffmpeg -version && ./ffmpeg -muxers 2>/dev/null |grep whip
+    runs-on: macos-latest
+
   test-done:
     needs:
       - fate
@@ -692,6 +802,8 @@ jobs:
       - openssl-1-1-1
       - openssl-3-0
       - openssl-latest
+      - build-windows
+      - build-macos
     steps:
       - run: echo 'All done'
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -838,40 +838,44 @@ jobs:
         run: |
           chmod +x ./ffmpeg
           ./ffmpeg -version && ./ffmpeg -muxers 2>/dev/null |grep whip
-      - name: Start SRS Docker container
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Start Pion and Stream with FFmpeg
         run: |
           set -euxo pipefail
-          docker run --rm -d -p 1935:1935 -p 1985:1985 -p 8080:8080 -p 8000:8000/udp \
-            ossrs/srs:5 ./objs/srs -c conf/rtc2rtmp.conf
-      - name: Streaming with FFmpeg
-        run: |
-          set -euxo pipefail
+          git clone https://github.com/pion/webrtc.git
+          cd webrtc/examples/whip-whep
+          go run *.go &
+
+          # Wait for Pion to be ready
+          for ((i=0; i<30; i++)); do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/whip | grep -qv "000"; then
+              echo "Pion is ready"
+              break
+            fi
+            echo "Waiting for Pion... ($i)"
+            sleep 1
+          done
+
+          cd $GITHUB_WORKSPACE
           nohup ./ffmpeg -t 30 -re -f lavfi -i testsrc=size=1280x720 -f lavfi -i sine=frequency=440 -pix_fmt yuv420p \
             -vcodec libx264 -profile:v baseline -r 25 -g 50 \
-            -f whip "http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream" \
+            -f whip -authorization "seanTest" "http://localhost:8080/whip" \
             1>ffstdout.log 2>ffstderr.log &
-          sleep 15
-      - name: Check SRS Streaming
-        run: |
-          set -euxo pipefail
-          for ((i=0; i<10; i++)); do
-            STREAM=$(curl -s http://localhost:1985/api/v1/streams/ | jq -r '.streams[].name')
-            if [[ "$STREAM" == "livestream" ]]; then
-              echo 'Test OK'
-              exit 0
-            fi
-            sleep 3
-          done
-          echo "Stream not found"
-          exit 1
-      - name: Stop FFmpeg
-        run: |
+          sleep 10
           pkill -SIGINT ffmpeg && sleep 3 || echo "FFmpeg process not found"
       - name: Show FFmpeg Logs
         if: always()
         run: |
           cat ffstdout.log || true
           cat ffstderr.log || true
+      - name: Check FFmpeg Streamed Successfully
+        run: |
+          set -euxo pipefail
+          cat ffstderr.log |grep -v 'Connection refused' |grep 'frame=' |grep -v 'frame=    0' && exit 0
+          echo "FFmpeg did not stream any frames" && exit 1
     runs-on: macos-latest
 
   test-done:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -748,31 +748,34 @@ jobs:
         run: |
           .\ffmpeg.exe -version
           .\ffmpeg.exe -muxers 2>$null | Select-String "whip"
-      - name: Start SRS Docker container
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Start Pion and Stream with FFmpeg
         shell: pwsh
         run: |
-          docker run --rm -d -p 1935:1935 -p 1985:1985 -p 8080:8080 -p 8000:8000/udp ossrs/srs:5 ./objs/srs -c conf/rtc2rtmp.conf
-      - name: Streaming with FFmpeg
-        shell: pwsh
-        run: |
-          Start-Process -NoNewWindow -FilePath ".\ffmpeg.exe" -ArgumentList "-t","30","-re","-f","lavfi","-i","testsrc=size=1280x720","-f","lavfi","-i","sine=frequency=440","-pix_fmt","yuv420p","-vcodec","libx264","-profile:v","baseline","-r","25","-g","50","-f","whip","http://localhost:1985/rtc/v1/whip/?app=live&stream=livestream" -RedirectStandardOutput ffstdout.log -RedirectStandardError ffstderr.log
-          Start-Sleep -Seconds 15
-      - name: Check SRS Streaming
-        shell: pwsh
-        run: |
-          for ($i=0; $i -lt 10; $i++) {
-            $response = Invoke-RestMethod -Uri "http://localhost:1985/api/v1/streams/"
-            if ($response.streams.name -contains "livestream") {
-              Write-Host "Test OK"
-              exit 0
+          git clone https://github.com/pion/webrtc.git
+          cd webrtc/examples/whip-whep
+          Start-Process -NoNewWindow -FilePath "go" -ArgumentList "run","." -RedirectStandardOutput pion-stdout.log -RedirectStandardError pion-stderr.log
+
+          # Wait for Pion to be ready
+          for ($i=0; $i -lt 30; $i++) {
+            try {
+              $response = Invoke-WebRequest -Uri "http://localhost:8080/whip" -Method Head -ErrorAction SilentlyContinue
+              if ($response.StatusCode -ne 0) {
+                Write-Host "Pion is ready"
+                break
+              }
+            } catch {
+              Write-Host "Waiting for Pion... ($i)"
+              Start-Sleep -Seconds 1
             }
-            Start-Sleep -Seconds 3
           }
-          Write-Host "Stream not found"
-          exit 1
-      - name: Stop FFmpeg
-        shell: pwsh
-        run: |
+
+          cd $env:GITHUB_WORKSPACE
+          Start-Process -NoNewWindow -FilePath ".\ffmpeg.exe" -ArgumentList "-t","30","-re","-f","lavfi","-i","testsrc=size=1280x720","-f","lavfi","-i","sine=frequency=440","-pix_fmt","yuv420p","-vcodec","libx264","-profile:v","baseline","-r","25","-g","50","-f","whip","-authorization","seanTest","http://localhost:8080/whip" -RedirectStandardOutput ffstdout.log -RedirectStandardError ffstderr.log
+          Start-Sleep -Seconds 10
           Get-Process ffmpeg -ErrorAction SilentlyContinue | Stop-Process
           Start-Sleep -Seconds 3
       - name: Show FFmpeg Logs
@@ -781,6 +784,16 @@ jobs:
         run: |
           if (Test-Path ffstdout.log) { Get-Content ffstdout.log }
           if (Test-Path ffstderr.log) { Get-Content ffstderr.log }
+      - name: Check FFmpeg Streamed Successfully
+        shell: pwsh
+        run: |
+          $stderr = Get-Content ffstderr.log -Raw
+          if ($stderr -match "frame=\s+\d+" -and $stderr -notmatch "frame=\s+0\s") {
+            Write-Host "FFmpeg streamed successfully"
+            exit 0
+          }
+          Write-Host "FFmpeg did not stream any frames"
+          exit 1
     runs-on: windows-latest
 
   build-macos:


### PR DESCRIPTION
Add build-windows and build-macos jobs to test FFmpeg compilation with OpenSSL, GnuTLS, and mbedTLS on both platforms.

- Windows: Uses MSYS2 environment with MinGW toolchain
- macOS: Uses Homebrew for dependencies
- Both platforms build mbedTLS from source when needed
- Verifies builds by checking version and WHIP muxer availability