### PR TITLE
avformat/tls_gnutls: actually send client cert if one is provided

### DIFF
--- a/libavformat/tls_gnutls.c
+++ b/libavformat/tls_gnutls.c
@@ -531,6 +531,7 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
     uint16_t gnutls_flags = 0;
     gnutls_x509_crt_t cert = NULL;
     gnutls_x509_privkey_t pkey = NULL;
+    int have_cert_pkey = 0;
     int ret;
 
     ff_gnutls_init();
@@ -540,16 +541,6 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
             goto fail;
     }
 
-    if (s->is_dtls)
-        gnutls_flags |= GNUTLS_DATAGRAM;
-
-    if (s->listen)
-        gnutls_flags |= GNUTLS_SERVER;
-    else
-        gnutls_flags |= GNUTLS_CLIENT;
-    gnutls_init(&c->session, gnutls_flags);
-    if (!s->listen && !s->numerichost)
-        gnutls_server_name_set(c->session, GNUTLS_NAME_DNS, s->host, strlen(s->host));
     gnutls_certificate_allocate_credentials(&c->cred);
     if (s->ca_file) {
         ret = gnutls_certificate_set_x509_trust_file(c->cred, s->ca_file, GNUTLS_X509_FMT_PEM);
@@ -573,6 +564,7 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
             ret = AVERROR(EIO);
             goto fail;
         }
+        have_cert_pkey = 1;
     } else if (s->cert_file || s->key_file) {
         av_log(h, AV_LOG_ERROR, "cert and key required\n");
     } else if (s->cert_buf && s->key_buf) {
@@ -584,6 +576,7 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
             ret = AVERROR(EINVAL);
             goto fail;
         }
+        have_cert_pkey = 1;
     } else if (s->cert_buf || s->key_buf) {
         av_log(h, AV_LOG_ERROR, "cert and key required\n");
     }
@@ -605,7 +598,27 @@ static int tls_open(URLContext *h, const char *uri, int flags, AVDictionary **op
             ret = AVERROR(EINVAL);
             goto fail;
         }
+
+        have_cert_pkey = 1;
     }
+
+    if (s->is_dtls)
+        gnutls_flags |= GNUTLS_DATAGRAM;
+
+    if (s->listen)
+        gnutls_flags |= GNUTLS_SERVER;
+    else {
+        gnutls_flags |= GNUTLS_CLIENT;
+#if GNUTLS_VERSION_NUMBER >= 0x030500
+        if (have_cert_pkey)
+            gnutls_flags |= GNUTLS_FORCE_CLIENT_CERT;
+#endif
+    }
+
+    gnutls_init(&c->session, gnutls_flags);
+
+    if (!s->listen && !s->numerichost)
+        gnutls_server_name_set(c->session, GNUTLS_NAME_DNS, s->host, strlen(s->host));
     gnutls_credentials_set(c->session, GNUTLS_CRD_CERTIFICATE, c->cred);
     gnutls_transport_set_pull_function(c->session, gnutls_url_pull);
     gnutls_transport_set_push_function(c->session, gnutls_url_push);


### PR DESCRIPTION
Without setting this flag, apparently gnutls will only send the client certificate according some logic based on what it thinks the server accepts.
This is not the case a lot of times.
Just force it to send the client cert the user supplied, if one was supplied, no matter what.

Fixes #22707